### PR TITLE
Change sbt url to dl.bintray

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -70,7 +70,7 @@ fi
  
 SBT_VERSION="$(get_supported_sbt_version ${BUILD_DIR})"
 SBT_JAR="sbt-launch.jar"
-SBT_URL="http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.5/$SBT_JAR"
+SBT_URL="https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.5/$SBT_JAR"
 ## in 0.10 start-script will depend on package, if packaging
 ## is required - it may not be, we can run .class files or a package-war
 ## instead.


### PR DESCRIPTION
Due to change of typesafe:
- https://www.typesafe.com/blog/migrating-repos-to-bintray
- https://github.com/travis-ci/travis-ci/issues/4527

Fixes #3
